### PR TITLE
chore: update reference for shared action

### DIFF
--- a/.github/workflows/generate-sdk.yaml
+++ b/.github/workflows/generate-sdk.yaml
@@ -11,5 +11,15 @@ jobs:
     name: Generate JavaScript SDK
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.ref }}
+          path: ${{github.workspace}}/sdk
       - name: Build JavaScript SDK
-        uses: Kong/shared-actions/build-js-sdk@main
+        uses: Kong/public-shared-actions/code-build-actions/build-js-sdk@v1.6.0
+        with:
+          app_directory: ${{ github.workspace }}
+          sdk_output_directory: ${{github.workspace}}/sdk
+          token: ${{secrets.GITHUB_TOKEN}}
+          dry-run: false
+          


### PR DESCRIPTION
This will fail until [this pr](https://github.com/Kong/public-shared-actions/pull/34) is merged.

Feedback from that PR requested that sourcecode checkout be done in the consuming workflow, rather than the action itself. So it now needs to specify `app_directory` and `sdk_output_directory`.