### PR TITLE
chore(package): bump to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@kong/sdk-portal-js",
   "main": "dist/index.js",
   "types": "./src/index.ts",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": false,
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
The published SDK version will match the Portal API version, which starts at 2.0.0.
Note that SDK v2.0.0 will be identical to v1.0.0.