### PR TITLE
chore: add devx bot token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GHA_TEAM_DEVX_KONG_BOT_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_PRIVATE_PUBLISH }}
         run: |
           yarn install --frozen-lockfile


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.2--canary.47.6e8f02a.1</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kong/sdk-portal-js@2.3.2--canary.47.6e8f02a.1
  # or 
  yarn add @kong/sdk-portal-js@2.3.2--canary.47.6e8f02a.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
