### PR TITLE
fix: remove skip check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on: [push]
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: contains(github.event.head_commit.message, 'ci skip') == 'false' && contains(github.event.head_commit.message, 'skip ci') == 'false'
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.3--canary.50.79ea62d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kong/sdk-portal-js@2.3.3--canary.50.79ea62d.0
  # or 
  yarn add @kong/sdk-portal-js@2.3.3--canary.50.79ea62d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
