### PR TITLE
fix: perhaps using different tokens

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create Release
         env:
-          GH_TOKEN: ${{ secrets.PORTAL_JS_SDK_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets.PORTAL_JS_SDK_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_PRIVATE_PUBLISH }}
         run: |


### PR DESCRIPTION
My suspicion is that `auto` needs to have one bot to make the PR, and one to approve it. Not 100% sure, but this seems probable.