### PR TITLE
Revert "chore/update-gh-token"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create Release
         env:
-          GH_TOKEN: ${{ secrets.API_OPS_GH_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets.PORTAL_JS_SDK_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_PRIVATE_PUBLISH }}
         run: |


### PR DESCRIPTION
Reverts Kong/sdk-portal-js#66
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.1--canary.71.cabfbdc.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kong/sdk-portal-js@2.6.1--canary.71.cabfbdc.0
  # or 
  yarn add @kong/sdk-portal-js@2.6.1--canary.71.cabfbdc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
