### PR TITLE
chore: update token for build to use api ops token

### DIFF
--- a/.github/workflows/generate-sdk.yaml
+++ b/.github/workflows/generate-sdk.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           app_directory: ${{ github.workspace }}
           sdk_output_directory: ${{ github.workspace }}/actions
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.API_OPS_GH_PAT }}
           
       - name: Commit SDK changes to the PR
         shell: bash


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.1--canary.72.5d4eea8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kong/sdk-portal-js@2.6.1--canary.72.5d4eea8.0
  # or 
  yarn add @kong/sdk-portal-js@2.6.1--canary.72.5d4eea8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
