### PR TITLE
chore: update release checkout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare repository
         run: git fetch --unshallow --tags


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.1--canary.77.d3a6372.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kong/sdk-portal-js@2.6.1--canary.77.d3a6372.0
  # or 
  yarn add @kong/sdk-portal-js@2.6.1--canary.77.d3a6372.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
