### PR TITLE
feat(sdk): automated oas update

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2040,7 +2040,6 @@ components:
       type: string
       enum:
         - required
-        - max_length
         - is_array
         - is_base64
         - is_boolean
@@ -2098,6 +2097,8 @@ components:
             - min_lowercase
             - min_uppercase
             - min_symbols
+            - min_items
+            - min
           nullable: false
           readOnly: true
         minimum:
@@ -2108,7 +2109,7 @@ components:
           example: body
         reason:
           type: string
-          example: is a required field
+          example: must have at least 8 characters
           readOnly: true
       additionalProperties: false
       required:
@@ -2116,6 +2117,38 @@ components:
         - reason
         - rule
         - minimum
+    InvalidParameterMaximumLength:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - max_length
+            - max_items
+            - max
+          nullable: false
+          readOnly: true
+        maximum:
+          type: integer
+          example: 8
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: must not have more than 8 characters
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - maximum
     InvalidParameterChoiceItem:
       type: object
       properties:
@@ -2190,6 +2223,7 @@ components:
         oneOf:
           - $ref: '#/components/schemas/InvalidParameterStandard'
           - $ref: '#/components/schemas/InvalidParameterMinimumLength'
+          - $ref: '#/components/schemas/InvalidParameterMaximumLength'
           - $ref: '#/components/schemas/InvalidParameterChoiceItem'
           - $ref: '#/components/schemas/InvalidParameterDependentItem'
       minItems: 1
@@ -2575,9 +2609,12 @@ components:
           readOnly: true
         latest_version:
           $ref: '#/components/schemas/LatestVersion'
+        public_labels:
+          $ref: '#/components/schemas/PublicLabels'
       additionalProperties: false
       required:
         - id
+        - public_labels
         - created_at
         - updated_at
         - name
@@ -2858,6 +2895,23 @@ components:
         - title
         - content
       title: ProductDocumentRaw
+    PublicLabels:
+      description: |
+        Public labels store information about an entity that can be used for filtering a list of objects.
+
+        Public labels are intended to store **PUBLIC** metadata. 
+
+        Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_".
+      type: object
+      example:
+        category: finance
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+      maxProperties: 50
+      title: PublicLabels
     NullableUUID:
       description: Contains a unique identifier for a resource.
       type: string
@@ -3523,6 +3577,8 @@ components:
           required:
             - name
             - id
+        public_labels:
+          $ref: '#/components/schemas/PublicLabels'
       additionalProperties: false
       required:
         - id
@@ -3532,6 +3588,7 @@ components:
         - document_count
         - version_count
         - latest_version
+        - public_labels
       title: ProductCatalogIndexSource
     SearchIndicesParameters:
       type: string
@@ -3859,6 +3916,8 @@ components:
               description: Great products are built with great care
               document_count: 5
               version_count: 5
+              public_labels:
+                env: test
               latest_version:
                 name: v5
                 id: 455b0beb-c3f7-4f8f-95f7-cd8ff0ee478e
@@ -4299,3 +4358,9 @@ tags:
       all of the described endpoints will return a 404 error
   - name: search
     description: The API for Konnect Portal Search.
+x-errors:
+  granted-scopes-unavailable:
+    description: |
+      The IDP used does not support granted scopes.
+    resolution: |
+      Switch to an IDP that allows you to grant specific scopes.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1497,6 +1497,52 @@ export type InvalidParameterDependentItemRuleEnum = typeof InvalidParameterDepen
 /**
  * 
  * @export
+ * @interface InvalidParameterMaximumLength
+ */
+export interface InvalidParameterMaximumLength {
+    /**
+     * 
+     * @type {string}
+     * @memberof InvalidParameterMaximumLength
+     */
+    'field': string;
+    /**
+     * invalid parameters rules
+     * @type {string}
+     * @memberof InvalidParameterMaximumLength
+     */
+    'rule': InvalidParameterMaximumLengthRuleEnum;
+    /**
+     * 
+     * @type {number}
+     * @memberof InvalidParameterMaximumLength
+     */
+    'maximum': number;
+    /**
+     * 
+     * @type {string}
+     * @memberof InvalidParameterMaximumLength
+     */
+    'source'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof InvalidParameterMaximumLength
+     */
+    'reason': string;
+}
+
+export const InvalidParameterMaximumLengthRuleEnum = {
+    MaxLength: 'max_length',
+    MaxItems: 'max_items',
+    Max: 'max'
+} as const;
+
+export type InvalidParameterMaximumLengthRuleEnum = typeof InvalidParameterMaximumLengthRuleEnum[keyof typeof InvalidParameterMaximumLengthRuleEnum];
+
+/**
+ * 
+ * @export
  * @interface InvalidParameterMinimumLength
  */
 export interface InvalidParameterMinimumLength {
@@ -1533,11 +1579,13 @@ export interface InvalidParameterMinimumLength {
 }
 
 export const InvalidParameterMinimumLengthRuleEnum = {
-    Length: 'min_length',
-    Digits: 'min_digits',
-    Lowercase: 'min_lowercase',
-    Uppercase: 'min_uppercase',
-    Symbols: 'min_symbols'
+    MinLength: 'min_length',
+    MinDigits: 'min_digits',
+    MinLowercase: 'min_lowercase',
+    MinUppercase: 'min_uppercase',
+    MinSymbols: 'min_symbols',
+    MinItems: 'min_items',
+    Min: 'min'
 } as const;
 
 export type InvalidParameterMinimumLengthRuleEnum = typeof InvalidParameterMinimumLengthRuleEnum[keyof typeof InvalidParameterMinimumLengthRuleEnum];
@@ -1577,7 +1625,7 @@ export interface InvalidParameterStandard {
  * @type InvalidParametersInner
  * @export
  */
-export type InvalidParametersInner = InvalidParameterChoiceItem | InvalidParameterDependentItem | InvalidParameterMinimumLength | InvalidParameterStandard;
+export type InvalidParametersInner = InvalidParameterChoiceItem | InvalidParameterDependentItem | InvalidParameterMaximumLength | InvalidParameterMinimumLength | InvalidParameterStandard;
 
 /**
  * invalid parameters rules
@@ -1587,7 +1635,6 @@ export type InvalidParametersInner = InvalidParameterChoiceItem | InvalidParamet
 
 export const InvalidRules = {
     Required: 'required',
-    MaxLength: 'max_length',
     IsArray: 'is_array',
     IsBase64: 'is_base64',
     IsBoolean: 'is_boolean',
@@ -2342,6 +2389,12 @@ export interface Product {
      * @memberof Product
      */
     'latest_version'?: LatestVersion | null;
+    /**
+     * Public labels store information about an entity that can be used for filtering a list of objects.  Public labels are intended to store **PUBLIC** metadata.   Keys must be of length 1-63 characters, and cannot start with \"kong\", \"konnect\", \"mesh\", \"kic\", or \"_\". 
+     * @type {{ [key: string]: string; }}
+     * @memberof Product
+     */
+    'public_labels': { [key: string]: string; };
 }
 /**
  * 
@@ -2435,6 +2488,12 @@ export interface ProductCatalogIndexSource {
      * @memberof ProductCatalogIndexSource
      */
     'latest_version': ProductCatalogIndexSourceLatestVersion | null;
+    /**
+     * Public labels store information about an entity that can be used for filtering a list of objects.  Public labels are intended to store **PUBLIC** metadata.   Keys must be of length 1-63 characters, and cannot start with \"kong\", \"konnect\", \"mesh\", \"kic\", or \"_\". 
+     * @type {{ [key: string]: string; }}
+     * @memberof ProductCatalogIndexSource
+     */
+    'public_labels': { [key: string]: string; };
 }
 /**
  * Last created version.


### PR DESCRIPTION
Generated OAS files from platform-api.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.15.5--canary.115.511c69d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kong/sdk-portal-js@2.15.5--canary.115.511c69d.0
  # or 
  yarn add @kong/sdk-portal-js@2.15.5--canary.115.511c69d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
