### PR TITLE
chore: add Harden Runner to all workflows

### DIFF
--- a/.github/workflows/check-pr-labels.yaml
+++ b/.github/workflows/check-pr-labels.yaml
@@ -8,6 +8,10 @@ jobs:
   check-pr-labels:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Use Node.js 18.x

--- a/.github/workflows/generate-sdk.yaml
+++ b/.github/workflows/generate-sdk.yaml
@@ -13,6 +13,10 @@ jobs:
     outputs:
       oas-modified: ${{ steps.oas-modified.outputs.any_modified }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
@@ -30,6 +34,10 @@ jobs:
     env:
       changes_exist: false
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Prepare repository

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -6,6 +6,10 @@ jobs:
   ensure-pinned-actions:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Ensure SHA pinned actions


### PR DESCRIPTION
This PR adds the Step Security Harden Runner step to all GitHub Actions workflows.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.16.1--canary.124.c6e810f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kong/sdk-portal-js@2.16.1--canary.124.c6e810f.0
  # or 
  yarn add @kong/sdk-portal-js@2.16.1--canary.124.c6e810f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
